### PR TITLE
Add Linux 5.18.7

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pve-kernel (5.18.7-6) pve; urgency=medium
+
+  * Update to Linux 5.18.7.
+
+ -- fw867 <mail.ffkykzs@gmail.com>  Sat, 25 Jun 2022 16:33:10 +0000
+
 pve-kernel (5.18.7-5) pve; urgency=medium
 
   * Update to Linux 5.18.7.


### PR DESCRIPTION
Automated pull request to update the kernel to Linux 5.18.7.

**Changelog:**
```
Source: pve-kernel
Version: 5.18.7-6
Distribution: pve
Urgency: medium
Maintainer: fw867 <mail.ffkykzs@gmail.com>
Timestamp: 1656174790
Date: Sat, 25 Jun 2022 16:33:10 +0000
Changes:
 pve-kernel (5.18.7-6) pve; urgency=medium
 .
   * Update to Linux 5.18.7.
```