### PR TITLE
Add Linux 6.0.8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,12 @@ pve-kernel (6.0.8-1) pve; urgency=medium
 
   * Update to Linux 6.0.8.
 
+ -- fw867 <mail.ffkykzs@gmail.com>  Mon, 14 Nov 2022 11:23:15 +0000
+
+pve-kernel (6.0.8-1) pve; urgency=medium
+
+  * Update to Linux 6.0.8.
+
  -- fw867 <mail.ffkykzs@gmail.com>  Fri, 11 Nov 2022 11:22:09 +0000
 
 pve-kernel (6.0.7-1) pve; urgency=medium


### PR DESCRIPTION
Automated pull request to update the kernel to Linux 6.0.8.

**Changelog:**
```
Source: pve-kernel
Version: 6.0.8-1
Distribution: pve
Urgency: medium
Maintainer: fw867 <mail.ffkykzs@gmail.com>
Timestamp: 1668424995
Date: Mon, 14 Nov 2022 11:23:15 +0000
Changes:
 pve-kernel (6.0.8-1) pve; urgency=medium
 .
   * Update to Linux 6.0.8.
```